### PR TITLE
Bump junit from 4.12 to 4.13.1 in /java

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
### Description

In this pull request, the version of the JUnit dependency in the `pom.xml` file is being updated from `4.12` to `4.13.1`.

- Update JUnit dependency version from `4.12` to `4.13.1` in the `pom.xml` file.